### PR TITLE
Add Raspberry Pi 1 support (tested with Pi1 model B rev2)

### DIFF
--- a/re_programmer.py
+++ b/re_programmer.py
@@ -47,7 +47,11 @@ def Main():
         parser.add_argument( '-v', '--version', action= 'version', version= textwrap.dedent("%(prog)s 1.2\ncopyright 2014 Ingo Flaschberger"))
         args = parser.parse_args()
 
-        os.system( '/sbin/modprobe spi-bcm2708')
+        try:
+                os.system( '/sbin/modprobe spi-bcm2708 -q')
+        except:
+                os.system( '/sbin/modprobe spi-bcm2835')
+
         if( not os.path.isdir( SAVE_PATH)):
                 os.system( 'mkdir ' + SAVE_PATH)
 


### PR DESCRIPTION
Hi,
first thanks for your great tool. I just add the Pi1 support, as I use it on a Pi1.

The principle is :
* We try to modprobe silently on bcm2708
* If it throws, try to modprobe (not silently to get the failure message if any) on bcm2835
* No catch, stop processing if it throws too

It works on my Pi1

sgallou
